### PR TITLE
added optional parameters to the run() method

### DIFF
--- a/lib/src/ez_runner.dart
+++ b/lib/src/ez_runner.dart
@@ -22,6 +22,9 @@ import 'model/EzTranslator.dart';
 /// [blocs] are custom BLOCs that can be added to the [EzGlobalBloc] to be accessable within the app.
 /// [cupertino] defines if the runner should use [CupertinoApp] instead of [MaterialApp].
 /// [locales] are the supported languages. The default is 'EN'.
+/// [initialRoute] initial application route.
+/// [routes] The application's top-level routing table. 
+/// [locale] The appilcation locale.
 /// [envPath] is the path for the environment configuration.
 /// [applicationPath] is the path for your application configuration.
 /// [externalUrl] is the url for external configuration.
@@ -45,6 +48,9 @@ import 'model/EzTranslator.dart';
 class EzRunner {
   static Future<void> run(Widget app, String title,
       {Map<Type, EzBlocBase> blocs,
+      String initialRoute,
+      Map<String, WidgetBuilder> routes = const <String, WidgetBuilder>{},
+      Locale locale,
       bool cupertino = false,
       List<Locale> locales = const [Locale('en')],
       String envPath,
@@ -69,10 +75,10 @@ class EzRunner {
     Widget wrapper;
     if (cupertino) {
       wrapper = getCupertinoWrapper(
-          app, title, locales, cupertinoThemeData, displayDebugBadge);
+          app, title, locales, cupertinoThemeData, displayDebugBadge, initialRoute: initialRoute, routes: routes, locale: locale);
     } else {
       wrapper = getMaterialWrapper(
-          app, title, locales, materialThemeData, displayDebugBadge);
+          app, title, locales, materialThemeData, displayDebugBadge, initialRoute: initialRoute, routes: routes, locale: locale);
     }
     if (blocs == null) {
       blocs = {};
@@ -95,8 +101,12 @@ Widget buildBlocWrapper(Widget wrapper, Map<Type, EzBlocBase> blocs) {
 }
 
 Widget getMaterialWrapper(Widget app, String title, List<Locale> locales,
-    ThemeData materialThemeData, bool displayDebugBadge) {
+    ThemeData materialThemeData, bool displayDebugBadge, {String initialRoute,
+      Map<String, WidgetBuilder> routes, Locale locale}) {
   return MaterialApp(
+      initialRoute: initialRoute,
+      routes: routes,
+      locale: locale,
       title: title,
       theme: materialThemeData != null
           ? materialThemeData
@@ -112,8 +122,12 @@ Widget getMaterialWrapper(Widget app, String title, List<Locale> locales,
 }
 
 Widget getCupertinoWrapper(Widget app, String title, List<Locale> locales,
-    CupertinoThemeData cupertinoThemeData, bool displayDebugBadge) {
+    CupertinoThemeData cupertinoThemeData, bool displayDebugBadge, {String initialRoute,
+      Map<String, WidgetBuilder> routes, Locale locale,}) {
   return CupertinoApp(
+      initialRoute: initialRoute,
+      routes: routes,    
+      locale: locale,
       title: title,
       theme: cupertinoThemeData != null
           ? cupertinoThemeData


### PR DESCRIPTION
added optional parameters to be used in MaterialApp or CupertinoApp:
initialRoute, routes, locale